### PR TITLE
Create environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: faunus-notebooks
+channels:
+  - nodefaults
+  - conda-forge
+dependencies:
+  - ipywidgets
+  - numpy
+  - scipy
+  - matplotlib


### PR DESCRIPTION
Create conda environment configuration file that includes ipywidgets. 

This file is mostly copied from [jupyter lab's environment file](https://github.com/jupyterlab/jupyterlab/blob/4dac6ee2047cf4ee1b0dccdb1046ac7529fa8e39/environment.yml)

ipywidgets have been difficult to install in the past because the plugin must also be registered with jupyter. Hopefully it will work this way.